### PR TITLE
Remove color path from launchfile

### DIFF
--- a/launch/load_tif.launch
+++ b/launch/load_tif.launch
@@ -4,7 +4,7 @@
 
     <node pkg="grid_map_geo" type="test_tif_loader" name="test_tif_loader" output="screen">
         <param name="tif_path" value="$(find grid_map_geo)/resources/sertig.tif"/>
-        <param name="color_path" value="$(find grid_map_geo)/resources/sertig_color.tif"/>
+        <!-- <param name="color_path" value="$(find grid_map_geo)/resources/sertig_color.tif"/> -->
     </node>
 
     <group if="$(arg visualization)">

--- a/src/grid_map_geo.cpp
+++ b/src/grid_map_geo.cpp
@@ -53,7 +53,6 @@ bool GridMapGeo::Load(const std::string &map_path, bool algin_terrain, const std
     bool color_loaded = addColorFromGeotiff(color_map_path);
   }
   if (!loaded) return false;
-  AddLayerDistanceTransform("distance_surface");
   return true;
 }
 
@@ -144,6 +143,7 @@ bool GridMapGeo::initializeFromGeotiff(const std::string &path, bool align_terra
   Eigen::Isometry3d transform = meshlab_translation * meshlab_rotation;  // Apply affine transformation.
   grid_map_ = grid_map_.getTransformedMap(transform, "elevation", grid_map_.getFrameId(), true);
   grid_map_ = grid_map_.getTransformedMap(transform, "max_elevation", grid_map_.getFrameId(), true);
+  std::cout << "Done reading DEM" << std::endl;
   return true;
 }
 

--- a/src/test_tif_loader.cpp
+++ b/src/test_tif_loader.cpp
@@ -67,6 +67,7 @@ int main(int argc, char **argv) {
     /// TODO: Publish gridmap
     MapPublishOnce(original_map_pub, map->getGridMap());
     ros::Duration(10.0).sleep();
+    ros::Duration(3.0).sleep();
   }
 
   ros::spin();


### PR DESCRIPTION
**Problem Description**
Fixes for addressing high resolution DEM: Fixes https://github.com/ethz-asl/grid_map_geo/issues/6

- Since the tif file is not provided by the repo, it should be removed from the launchfile.
- The distance transform of the dem is not run on load

**Possible Alternatives**
Check for the file and ignore if the file doesn't exist