### PR TITLE
Fix color channels

### DIFF
--- a/src/grid_map_geo.cpp
+++ b/src/grid_map_geo.cpp
@@ -197,9 +197,9 @@ bool GridMapGeo::addColorFromGeotiff(const std::string &path) {
     int x = width - 1 - gridMapIndex(0);
     int y = gridMapIndex(1);
     Eigen::Vector3i colorVector;
-    colorVector(2) = data_red[gridMapIndex(0) + width * gridMapIndex(1)];
+    colorVector(0) = data_red[gridMapIndex(0) + width * gridMapIndex(1)];
     colorVector(1) = data_green[gridMapIndex(0) + width * gridMapIndex(1)];
-    colorVector(0) = data_blue[gridMapIndex(0) + width * gridMapIndex(1)];
+    colorVector(2) = data_blue[gridMapIndex(0) + width * gridMapIndex(1)];
     grid_map::colorVectorToValue(colorVector, layer_color(x, y));
   }
   return true;


### PR DESCRIPTION
**Problem Description**
The color vector were ordered in the wrong way when being passed to the color value calculation.

This was only apparent when water fronts in the map was not being shown as blue.

**Before PR**
![rviz_screenshot_2022_12_20-22_11_37](https://user-images.githubusercontent.com/5248102/208767771-a4eb8188-28af-4f5d-8468-74f91fb42349.png)

**After PR**
After the correction, the terrain color looks much more realistic
![rviz_screenshot_2022_12_20-22_10_17](https://user-images.githubusercontent.com/5248102/208767846-6511a150-9924-44ea-8b6e-41b57407e26e.png)
