### PR TITLE
Fix path to rviz config

### DIFF
--- a/launch/load_tif_launch.xml
+++ b/launch/load_tif_launch.xml
@@ -9,6 +9,6 @@
     </node>
 
     <group if="$(var rviz)">
-        <node exec="rviz2" name="rviz2" pkg="rviz2"  args="-d $(find-pkg-share grid_map_geo)/launch/config.rviz" />
+        <node exec="rviz2" name="rviz2" pkg="rviz2"  args="-d $(find-pkg-share grid_map_geo)/rviz/config.rviz" />
     </group>
 </launch>


### PR DESCRIPTION
**Problem Description**
This fixes the issue where the rviz config path was misconfigured for the xml launchfile

- Fixes regression from: https://github.com/ethz-asl/grid_map_geo/pull/27