### PR TITLE
Add missing rviz plugin dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,7 @@
   <depend>rclcpp</depend>
   <depend>yaml_cpp_vendor</depend>
   <exec_depend>ros2launch</exec_depend>
+  <exec_depend>grid_map_rviz_plugin</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
This adds a missing dependency on the rviz plugin. Without this, rviz will not load the grid map panel. 