### PR TITLE
Install resource folder and use correct topic for rviz elevation map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,11 @@ install(DIRECTORY
   DESTINATION share/${PROJECT_NAME}/
 )
 
+install(DIRECTORY
+  resources
+  DESTINATION share/${PROJECT_NAME}/
+)
+
 # Test
 include(CTest)
 if(BUILD_TESTING)

--- a/launch/load_tif_launch.xml
+++ b/launch/load_tif_launch.xml
@@ -3,12 +3,12 @@
     <arg name="location" default="sargans"/>
     <node pkg="tf2_ros" exec="static_transform_publisher" name="world_map" args="--frame-id world --child-frame-id map"/>
 
-    <node pkg="grid_map_geo" exec="test_tif_loader" name="test_tif_loader" output="screen">
+    <node pkg="grid_map_geo" exec="test_tif_loader" name="test_tif_loader" namespace="grid_map_geo" output="screen">
         <param name="tif_path" value="$(find-pkg-share grid_map_geo)/resources/sargans.tif"/>
         <param name="tif_color_path" value="$(find-pkg-share grid_map_geo)/resources/sargans_color.tif"/>
     </node>
 
     <group if="$(var rviz)">
-        <node exec="rviz2" name="rviz2" pkg="rviz2"  args="-d $(find-pkg-share grid_map_geo)/rviz/config.rviz" />
+        <node pkg="rviz2" exec="rviz2" name="rviz2" args="-d $(find-pkg-share grid_map_geo)/rviz/config.rviz"/>
     </group>
 </launch>


### PR DESCRIPTION
I added a symlink to the terrain-models, and this gets it installed from the source tree.  The resource folder needs to be installed and will be empty for people who don't have sargans.tif. In order for it to be tracked by git and not fail the build in case its empty, I added a placeholder `.gitkeep` folder.

 RVIZ was subscribed to the wrong topic, so I fixed that too. 


With the above changes, the XML launch file works:
```bash
ros2 launch grid_map_geo load_tif_launch.xml
```

![image](https://github.com/ethz-asl/grid_map_geo/assets/25047695/88782358-6abf-413e-9b7d-0e6c50b60795)
