### PR TITLE
Fix launching with no color when not configured for a color tif file

### DIFF
--- a/src/test_tif_loader.cpp
+++ b/src/test_tif_loader.cpp
@@ -53,7 +53,7 @@ class MapPublisher : public rclcpp::Node {
     original_map_pub_ = this->create_publisher<grid_map_msgs::msg::GridMap>("elevation_map", 1);
 
     std::string file_path = this->declare_parameter("tif_path", ".");
-    std::string color_path = this->declare_parameter("tif_color_path", ".");
+    std::string color_path = this->declare_parameter("tif_color_path", "");
 
     RCLCPP_INFO_STREAM(get_logger(), "file_path " << file_path);
     RCLCPP_INFO_STREAM(get_logger(), "color_path " << color_path);


### PR DESCRIPTION
# Purpose

The default param for the color_path on test_tif_loader is `"."` ( a period). That said, the logic in grid_map_geo.cpp is checking for empty string to determine whether to load the color data. 

Thus, if a user wants to load just an elevation map with no color data, they would have to change the default to empty string in their launch file, which is not that intuitive. 

This PR is a trivial fix for the issue that can be merged before #38.

# Demo

```bash
$ ros2 run grid_map_geo test_tif_loader --ros-args -p tif_path:=/home/ryan/Dev/ros2_ws/src/grid_map_geo/install/grid_map_geo/share/grid_map_geo/resources/sargans.tif
[INFO] [1705212505.372827098] [map_publisher]: file_path /home/ryan/Dev/ros2_ws/src/grid_map_geo/install/grid_map_geo/share/grid_map_geo/resources/sargans.tif
[INFO] [1705212505.372887373] [map_publisher]: color_path 

Loading GeoTIFF file for gridmap

Wkt ProjectionRef: PROJCS["CH1903 / LV03",GEOGCS["CH1903",DATUM["CH1903",SPHEROID["Bessel 1841",6377397.155,299.1528128,AUTHORITY["EPSG","7004"]],AUTHORITY["EPSG","6149"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4149"]],PROJECTION["Hotine_Oblique_Mercator_Azimuth_Center"],PARAMETER["latitude_of_center",46.9524055555556],PARAMETER["longitude_of_center",7.43958333333333],PARAMETER["azimuth",90],PARAMETER["rectified_grid_angle",90],PARAMETER["scale_factor",1],PARAMETER["false_easting",600000],PARAMETER["false_northing",200000],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","21781"]]
Width: 748 Height: 1220 Resolution: 10
```