### PR TITLE
Hide GDAL includes and link as PRIVATE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ target_include_directories(${PROJECT_NAME}
   "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>"
 )
 
-target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen GDAL::GDAL)
+target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen PRIVATE GDAL::GDAL)
 
 ament_target_dependencies(${PROJECT_NAME} PUBLIC
   grid_map_core

--- a/include/grid_map_geo/grid_map_geo.hpp
+++ b/include/grid_map_geo/grid_map_geo.hpp
@@ -39,20 +39,6 @@
 #include <grid_map_core/GridMap.hpp>
 #include <grid_map_core/iterators/GridMapIterator.hpp>
 
-#if __APPLE__
-#include <cpl_string.h>
-#include <gdal.h>
-#include <gdal_priv.h>
-#include <ogr_p.h>
-#include <ogr_spatialref.h>
-#else
-#include <gdal/cpl_string.h>
-#include <gdal/gdal.h>
-#include <gdal/gdal_priv.h>
-#include <gdal/ogr_p.h>
-#include <gdal/ogr_spatialref.h>
-#endif
-
 #include <iostream>
 struct Location {
   ESPG espg{ESPG::WGS84};

--- a/src/grid_map_geo.cpp
+++ b/src/grid_map_geo.cpp
@@ -43,6 +43,20 @@
 #include <grid_map_core/iterators/CircleIterator.hpp>
 #include <grid_map_core/iterators/GridMapIterator.hpp>
 
+#if __APPLE__
+#include <cpl_string.h>
+#include <gdal.h>
+#include <gdal_priv.h>
+#include <ogr_p.h>
+#include <ogr_spatialref.h>
+#else
+#include <gdal/cpl_string.h>
+#include <gdal/gdal.h>
+#include <gdal/gdal_priv.h>
+#include <gdal/ogr_p.h>
+#include <gdal/ogr_spatialref.h>
+#endif
+
 GridMapGeo::GridMapGeo() {}
 
 GridMapGeo::~GridMapGeo() {}


### PR DESCRIPTION
# Purpose

This moves `gdal` to the implementation and links it as `PRIVATE`. The reason to do this is that GDAL is an implementation detail and shouldn't be part of the public API. It allows future flexibility to choose a different library.

# Risk

If users have included grid_map_geo, and rely on transitive includes to access GDAL (bad practice), they will need to link directly to it in their builds and add proper includes.
