### PR TITLE
Use available clang-format version for Ubuntu 22

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -18,22 +18,19 @@ jobs:
     container: ${{ matrix.config.container }}
     steps:
     - uses: actions/checkout@v4
-    - name: Install Dependencies
-      working-directory: 
+      with:
+        path: src/grid_map_geo
+    - name: Install Dependencies with Rosdep
       run: |
         apt update
-        apt install -y python3-wstool libgdal-dev
+        rosdep update
+        source /opt/ros/${{matrix.config.rosdistro}}/setup.bash
+        rosdep install --from-paths src --ignore-src -y
       shell: bash
-    - name: Build Test
+    - name: Colcon Build (Release)
       working-directory: 
       run: |
-        mkdir -p $HOME/ros2_ws/src;
-        cd $HOME/ros2_ws/src
-        ln -s $GITHUB_WORKSPACE
-        cd $HOME/ros2_ws
-        source /opt/ros/humble/setup.bash
-        rosdep update
-        rosdep install --from-paths src --ignore-src -y --rosdistro ${{matrix.config.rosdistro}}
+        source /opt/ros/${{matrix.config.rosdistro}}/setup.bash
         colcon build --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to grid_map_geo
       shell: bash
     # - name: unit_tests

--- a/.github/workflows/check_style.yml
+++ b/.github/workflows/check_style.yml
@@ -14,16 +14,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container:
-        - 'px4io/px4-dev-simulation-focal:2020-09-14'
-    container: ${{ matrix.container }}
+        config:
+          - {rosdistro: 'humble', container: 'osrf/ros:humble-desktop'}
+    container: ${{ matrix.config.container }}
     steps:
     - uses: actions/checkout@v4
-    - name: submodule update
-      run: git submodule update --init --recursive
-    - name: Install clang-format
-      run: apt update && apt install -y clang-format-6.0
+      with:
+        path: src/grid_map_geo
+    - name: Install Dependencies with Rosdep
+      run: |
+        apt update
+        rosdep update
+        source /opt/ros/${{matrix.config.rosdistro}}/setup.bash
+        rosdep install --from-paths src --ignore-src -y --dependency-types test
+      shell: bash
     - name: Check Code format
-      working-directory: Tools
+      working-directory: src/grid_map_geo/Tools
       run: |
         ./check_code_format.sh ..

--- a/Tools/fix_code_style.sh
+++ b/Tools/fix_code_style.sh
@@ -13,9 +13,9 @@ fi
 for arg in "$@"
 do
     if [ -f $arg ]; then
-        clang-format-6.0 -i -style='{BasedOnStyle: google, ColumnLimit: 120}' $arg
+        clang-format -i -style='{BasedOnStyle: google, ColumnLimit: 120}' $arg
     elif [ -d $arg ]; then
-        find $arg -iname '*.h' -o -iname '*.cpp' -o -iname '*.hpp' | xargs clang-format-6.0 -i -style='{BasedOnStyle: google, ColumnLimit: 120}'
+        find $arg -iname '*.h' -o -iname '*.cpp' -o -iname '*.hpp' | xargs clang-format -i -style='{BasedOnStyle: google, ColumnLimit: 120}'
         find $arg -iname '*.h' -o -iname '*.cpp' -o -iname '*.hpp' | xargs chmod 644
     fi
 done

--- a/include/grid_map_geo/grid_map_geo.hpp
+++ b/include/grid_map_geo/grid_map_geo.hpp
@@ -34,13 +34,12 @@
 #ifndef GRID_MAP_GEO_H
 #define GRID_MAP_GEO_H
 
-#include "grid_map_geo/transform.hpp"
-
 #include <grid_map_core/GridMap.hpp>
 #include <grid_map_core/iterators/GridMapIterator.hpp>
-#include "tf2_ros/transform_broadcaster.h"
-
 #include <iostream>
+
+#include "grid_map_geo/transform.hpp"
+#include "tf2_ros/transform_broadcaster.h"
 struct Location {
   ESPG espg{ESPG::WGS84};
   Eigen::Vector3d position{Eigen::Vector3d::Zero()};
@@ -86,20 +85,17 @@ class GridMapGeo {
 
   /**
    * @brief Get the name of the coordinate frame of the dataset
-   * 
-   * @return std::string 
+   *
+   * @return std::string
    */
   std::string getCoordinateName() { return coordinate_name_; };
 
-
   /**
    * @brief Overloading terrain loading with only elevation
-   * 
+   *
    * @param map_path Path to dsm path (Supported formats are *.tif)
    */
-  bool Load(const std::string& map_path) {
-    Load(map_path, "");
-  }
+  bool Load(const std::string& map_path) { Load(map_path, ""); }
 
   /**
    * @brief Helper function for loading terrain from path
@@ -109,7 +105,7 @@ class GridMapGeo {
    * @return true Successfully loaded terrain
    * @return false Failed to load terrain
    */
-  bool Load(const std::string& map_path, const std::string &color_map_path);
+  bool Load(const std::string& map_path, const std::string& color_map_path);
 
   /**
    * @brief Initialize grid map from a geotiff file

--- a/package.xml
+++ b/package.xml
@@ -25,6 +25,8 @@
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>rviz2</exec_depend>
 
+  <test_depend>clang-format</test_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/src/grid_map_geo.cpp
+++ b/src/grid_map_geo.cpp
@@ -58,7 +58,7 @@
 #include <gdal/ogr_spatialref.h>
 #endif
 
-GridMapGeo::GridMapGeo(const std::string& frame_id) { frame_id_ = frame_id; }
+GridMapGeo::GridMapGeo(const std::string &frame_id) { frame_id_ = frame_id; }
 
 GridMapGeo::~GridMapGeo() {}
 

--- a/src/test_tif_loader.cpp
+++ b/src/test_tif_loader.cpp
@@ -37,14 +37,12 @@
  * @author Jaeyoung Lim <jalim@ethz.ch>
  */
 
+#include "geometry_msgs/msg/transform_stamped.hpp"
 #include "grid_map_geo/grid_map_geo.hpp"
-
-#include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/string.hpp"
-
 #include "grid_map_msgs/msg/grid_map.h"
 #include "grid_map_ros/GridMapRosConverter.hpp"
-#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
 #include "tf2_ros/static_transform_broadcaster.h"
 
 using namespace std::chrono_literals;
@@ -52,7 +50,6 @@ using namespace std::chrono_literals;
 class MapPublisher : public rclcpp::Node {
  public:
   MapPublisher() : Node("map_publisher") {
-
     std::string file_path = this->declare_parameter("tif_path", ".");
     std::string color_path = this->declare_parameter("tif_color_path", ".");
     std::string frame_id = this->declare_parameter("frame_id", "map");

--- a/test/test_grid_map_geo.cpp
+++ b/test/test_grid_map_geo.cpp
@@ -1,7 +1,8 @@
-#include "grid_map_geo/transform.hpp"
-
 #include <gtest/gtest.h>
+
 #include <iostream>
+
+#include "grid_map_geo/transform.hpp"
 
 TEST(GridMapTest, geoTransform) {
   Eigen::Vector3d berghaus_wgs84(46.7209147, 9.9219592, 488.0);


### PR DESCRIPTION
# Purpose

ROS2 (on humble) comes with clang-format 14, but the scripts hard code clang-format 6. You can't install it in Ubuntu 22. Thus, it's time to migrate up a few versions.
```
$ sudo apt install clang-format-6.0
[sudo] password for ryan: 
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
E: Unable to locate package clang-format-6.0
E: Couldn't find any package by glob 'clang-format-6.0'
```

# Risk

 Note - running version 14 results in the following diff (small):
```
ryan@B650-970:~/Dev/ros2_ws/src/grid_map_geo/Tools$ ./check_code_format.sh 
diff --git a/include/grid_map_geo/grid_map_geo.hpp b/include/grid_map_geo/grid_map_geo.hpp
index 7d293b6..6e98f78 100644
--- a/include/grid_map_geo/grid_map_geo.hpp
+++ b/include/grid_map_geo/grid_map_geo.hpp
@@ -37,2 +36,0 @@
-#include "grid_map_geo/transform.hpp"
-
@@ -41,0 +40,2 @@
+#include "grid_map_geo/transform.hpp"
+
diff --git a/src/test_tif_loader.cpp b/src/test_tif_loader.cpp
index a1dddc4..4951269 100644
--- a/src/test_tif_loader.cpp
+++ b/src/test_tif_loader.cpp
@@ -41,4 +40,0 @@
-
-#include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/string.hpp"
-
@@ -46,0 +43,2 @@
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/string.hpp"
diff --git a/test/test_grid_map_geo.cpp b/test/test_grid_map_geo.cpp
index cb1c005..738be37 100644
--- a/test/test_grid_map_geo.cpp
+++ b/test/test_grid_map_geo.cpp
@@ -1,2 +0,0 @@
-#include "grid_map_geo/transform.hpp"
-
@@ -3,0 +2 @@
+
@@ -5,0 +5,2 @@
+#include "grid_map_geo/transform.hpp"
+
Code style check failed, please run clang-format (e.g. with scripts/fix_code_style.sh)
```

I've applied the diff, and we now enfoce the same version of clang that is installed on Ubuntu 22.