### PR TITLE
Add missing timestamp for grid_map message when publishing

### DIFF
--- a/src/test_tif_loader.cpp
+++ b/src/test_tif_loader.cpp
@@ -66,6 +66,7 @@ class MapPublisher : public rclcpp::Node {
  private:
   void timer_callback() {
     auto msg = grid_map::GridMapRosConverter::toMessage(map_->getGridMap());
+    msg->header.stamp = now();
     original_map_pub_->publish(std::move(msg));
   }
   rclcpp::TimerBase::SharedPtr timer_;


### PR DESCRIPTION
# Purpose

Timestamp the grid_map message based on when it was sent. This is a precursor to doing dynamic tiles, where the grid map is updating throughout the flight

# Risk 

None