### PR TITLE
Validate projection is valid

### DIFF
--- a/src/grid_map_geo.cpp
+++ b/src/grid_map_geo.cpp
@@ -78,6 +78,13 @@ bool GridMapGeo::initializeFromGeotiff(const std::string &path, bool align_terra
   }
 
   const char *pszProjection = dataset->GetProjectionRef();
+
+  if (strlen(pszProjection) == 0) {
+    // https://gdal.org/user/raster_data_model.html#coordinate-system
+    std::cerr << std::endl << "Wkt ProjectionRef is unknown!" << std::endl;
+    return false;
+  }
+
   std::cout << std::endl << "Wkt ProjectionRef: " << pszProjection << std::endl;
 
   // Get image metadata


### PR DESCRIPTION
# Purpose

When calling `dataset->GetProjectionRef`, there is a chance it will return an empty string. This means the projection is invalid. If that's true, the grid map should not be loaded. Without validation, later code may be invalid.

# Risks

Low, I tested it on the TIF and SRTM data files, and they both return valid projections.

# Reference

https://gdal.org/user/raster_data_model.html#coordinate-system