### PR TITLE
Use std::array over raw array for transforms

### DIFF
--- a/src/grid_map_geo.cpp
+++ b/src/grid_map_geo.cpp
@@ -39,6 +39,7 @@
 
 #include "grid_map_geo/grid_map_geo.hpp"
 
+#include <array>
 #include <grid_map_core/GridMapMath.hpp>
 #include <grid_map_core/iterators/CircleIterator.hpp>
 #include <grid_map_core/iterators/GridMapIterator.hpp>
@@ -66,8 +67,8 @@ bool GridMapGeo::initializeFromGeotiff(const std::string &path, bool align_terra
   std::cout << std::endl << "Loading GeoTIFF file for gridmap" << std::endl;
 
   double originX, originY, pixelSizeX, pixelSizeY;
-  double geoTransform[6];
-  if (dataset->GetGeoTransform(geoTransform) == CE_None) {
+  std::array<double, 6> geoTransform;
+  if (dataset->GetGeoTransform(geoTransform.data()) == CE_None) {
     originX = geoTransform[0];
     originY = geoTransform[3];
     pixelSizeX = geoTransform[1];
@@ -157,8 +158,8 @@ bool GridMapGeo::addColorFromGeotiff(const std::string &path) {
   std::cout << std::endl << "Loading color layer from GeoTIFF file for gridmap" << std::endl;
 
   double originX, originY, pixelSizeX, pixelSizeY;
-  double geoTransform[6];
-  if (dataset->GetGeoTransform(geoTransform) == CE_None) {
+  std::array<double, 6> geoTransform;
+  if (dataset->GetGeoTransform(geoTransform.data()) == CE_None) {
     originX = geoTransform[0];
     originY = geoTransform[3];
     pixelSizeX = geoTransform[1];
@@ -218,8 +219,8 @@ bool GridMapGeo::addLayerFromGeotiff(const std::string &layer_name, const std::s
   std::cout << std::endl << "Loading color layer from GeoTIFF file for gridmap" << std::endl;
 
   double originX, originY, pixelSizeX, pixelSizeY;
-  double geoTransform[6];
-  if (dataset->GetGeoTransform(geoTransform) == CE_None) {
+  std::array<double, 6> geoTransform;
+  if (dataset->GetGeoTransform(geoTransform.data()) == CE_None) {
     originX = geoTransform[0];
     originY = geoTransform[3];
     pixelSizeX = geoTransform[1];


### PR DESCRIPTION
# Purpose

`std::array` has more compile time safety and carries the length with the object over a raw array. 

# Risk

None