### PR TITLE
CI: Split docs workflows and add write permissions for pages deployment

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -17,10 +17,7 @@ jobs:
           - {rosdistro: 'humble', container: 'osrf/ros:humble-desktop'}
     container: ${{ matrix.config.container }}
     steps:
-    - uses: actions/checkout@v1
-      with:
-        token: ${{ secrets.ACCESS_TOKEN }}
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: actions/checkout@v4
     - name: Install Dependencies
       working-directory: 
       run: |

--- a/.github/workflows/check_style.yml
+++ b/.github/workflows/check_style.yml
@@ -18,7 +18,7 @@ jobs:
         - 'px4io/px4-dev-simulation-focal:2020-09-14'
     container: ${{ matrix.container }}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: submodule update
       run: git submodule update --init --recursive
     - name: Install clang-format

--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -1,6 +1,8 @@
-name: Build Test
+name: Doxygen Pages
 on:
   push:
+    branches:
+      - 'ros2'
   pull_request:
     branches:
     - '*'
@@ -10,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+    permissions:
+      contents: write
     steps:
     - uses: actions/checkout@v4
     - uses: mattnotmitt/doxygen-action@v1.9.5

--- a/.github/workflows/doxygen_build.yml
+++ b/.github/workflows/doxygen_build.yml
@@ -1,24 +1,18 @@
-name: Doxygen Pages
+name: Doxygen Build
 on:
   push:
     branches:
       - 'ros2'
   pull_request:
     branches:
-    - '*'
+      - '*'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-    permissions:
-      contents: write
     steps:
     - uses: actions/checkout@v4
     - uses: mattnotmitt/doxygen-action@v1.9.5
-    - uses: peaceiris/actions-gh-pages@v3
-      with: 
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./html
 

--- a/.github/workflows/doxygen_deploy.yml
+++ b/.github/workflows/doxygen_deploy.yml
@@ -9,6 +9,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+    permissions:
+      contents: write
     steps:
     - uses: ./.github/workflows/doxygen_build.yml
     - uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/doxygen_deploy.yml
+++ b/.github/workflows/doxygen_deploy.yml
@@ -1,0 +1,17 @@
+name: Doxygen Deploy to GH Pages
+on:
+  push:
+    branches:
+      - 'ros2'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+    - uses: ./.github/workflows/doxygen_build.yml
+    - uses: peaceiris/actions-gh-pages@v3
+      with: 
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./html


### PR DESCRIPTION
This is an attempted fix for #51. Oh yea, and rename the job to be correct.

Edit: Doh - no dice: https://github.com/ethz-asl/grid_map_geo/actions/runs/7565414848/job/20601127489?pr=52#step:5:145

The docs for `peaceiris/actions-gh-pages` do not seem suffient, and the other repo-wide permissions change is a security risk.

The approach here is to split the jobs, and only try deploying on `ros2` after it's merged. Might break `ros2` branch, and if it does, we'll just remove pages deploy and find another approach.  