### PR TITLE
Remove unused variable

### DIFF
--- a/include/grid_map_geo/grid_map_geo.hpp
+++ b/include/grid_map_geo/grid_map_geo.hpp
@@ -177,8 +177,6 @@ class GridMapGeo {
    */
   void AddLayerNormals(std::string reference_layer);
 
-  geometry_msgs::msg::TransformStamped static_transformStamped_;
-
  protected:
   grid_map::GridMap grid_map_;
   Location maporigin_;


### PR DESCRIPTION
Forward port this to ROS 2:
https://github.com/ethz-asl/grid_map_geo/commit/85b075f591c6f972f2faa5bcd0885a5ad924f000

And this patch:
https://github.com/ethz-asl/grid_map_geo/commit/7c6445d6bfdb3b9fc67b1dfd361071ba194f1dfa

I want to get the ros2 branch up to date with the incremental VRT loading support. after this. Just a few others.
https://github.com/ethz-asl/grid_map_geo/compare/ros2...master

The diffs are small because a lot was already copied (IE, a trivial unused variable change). 




