### PR TITLE
enable usage of non-CH1903 Geotiffs, and EPSG rename

### DIFF
--- a/grid_map_geo/include/grid_map_geo/grid_map_geo.h
+++ b/grid_map_geo/include/grid_map_geo/grid_map_geo.h
@@ -46,7 +46,7 @@
 #include <gdal/ogr_spatialref.h>
 #include <iostream>
 struct Location {
-  ESPG espg{ESPG::WGS84};
+  EPSG epsg{EPSG::WGS84};
   Eigen::Vector3d position{Eigen::Vector3d::Zero()};
 };
 
@@ -75,7 +75,7 @@ class GridMapGeo {
    * @param src_coord
    * @param origin
    */
-  void setGlobalOrigin(ESPG src_coord, const Eigen::Vector3d origin);
+  void setGlobalOrigin(EPSG src_coord, const Eigen::Vector3d origin);
 
   /**
    * @brief Get the Global Origin object
@@ -83,8 +83,8 @@ class GridMapGeo {
    * @param src_coord
    * @param origin
    */
-  void getGlobalOrigin(ESPG& src_coord, Eigen::Vector3d& origin) {
-    src_coord = maporigin_.espg;
+  void getGlobalOrigin(EPSG& src_coord, Eigen::Vector3d& origin) {
+    src_coord = maporigin_.epsg;
     origin = maporigin_.position;
   };
 

--- a/grid_map_geo/include/grid_map_geo/transform.h
+++ b/grid_map_geo/include/grid_map_geo/transform.h
@@ -41,7 +41,7 @@
 
 #include <Eigen/Dense>
 
-enum class ESPG { ECEF = 4978, WGS84 = 4326, WGS84_32N = 32632, CH1903_LV03 = 21781 };
+enum class EPSG { ECEF = 4978, WGS84 = 4326, WGS84_32N = 32632, CH1903_LV03 = 21781, AT_GK_WEST = 31254 };
 
 /**
  * @brief Helper function for transforming using gdal
@@ -51,7 +51,7 @@ enum class ESPG { ECEF = 4978, WGS84 = 4326, WGS84_32N = 32632, CH1903_LV03 = 21
  * @param source_coordinates
  * @return Eigen::Vector3d
  */
-inline Eigen::Vector3d transformCoordinates(ESPG src_coord, ESPG tgt_coord, const Eigen::Vector3d source_coordinates) {
+inline Eigen::Vector3d transformCoordinates(EPSG src_coord, EPSG tgt_coord, const Eigen::Vector3d source_coordinates) {
   OGRSpatialReference source, target;
   source.importFromEPSG(static_cast<int>(src_coord));
   target.importFromEPSG(static_cast<int>(tgt_coord));
@@ -75,7 +75,7 @@ inline Eigen::Vector3d transformCoordinates(ESPG src_coord, ESPG tgt_coord, cons
  * @param source_coordinates
  * @return Eigen::Vector3d
  */
-inline Eigen::Vector3d transformCoordinates(ESPG src_coord, const std::string wkt,
+inline Eigen::Vector3d transformCoordinates(EPSG src_coord, const std::string wkt,
                                             const Eigen::Vector3d source_coordinates) {
   OGRSpatialReference source, target;
   char* wkt_string = const_cast<char*>(wkt.c_str());

--- a/grid_map_geo/src/grid_map_geo.cpp
+++ b/grid_map_geo/src/grid_map_geo.cpp
@@ -99,9 +99,8 @@ bool GridMapGeo::initializeFromGeotiff(const std::string &path) {
 
   double mapcenter_e = originX + pixelSizeX * width * 0.5;
   double mapcenter_n = originY + pixelSizeY * height * 0.5;
-  maporigin_.espg = ESPG::CH1903_LV03;
   maporigin_.position = Eigen::Vector3d(mapcenter_e, mapcenter_n, 0.0);
-
+  maporigin_.epsg = static_cast<EPSG>(std::stoi(spatial_ref->GetAttrValue("AUTHORITY", 1)));
   Eigen::Vector2d position{Eigen::Vector2d::Zero()};
 
   grid_map_.setGeometry(length, resolution, position);
@@ -184,7 +183,7 @@ bool GridMapGeo::initializeFromVrt(const std::string &path, const Eigen::Vector2
   grid_map::Length length(lengthX, lengthY);
   std::cout << "length: " << length.transpose() << std::endl;
 
-  maporigin_.espg = static_cast<ESPG>(std::stoi(epsg_code));
+  maporigin_.epsg = static_cast<EPSG>(std::stoi(epsg_code));
   maporigin_.position = map_center.head(2);
 
   Eigen::Vector2d position{Eigen::Vector2d::Zero()};
@@ -414,9 +413,9 @@ bool GridMapGeo::AddLayerOffset(const double offset_distance, const std::string 
   return true;
 }
 
-void GridMapGeo::setGlobalOrigin(ESPG src_coord, const Eigen::Vector3d origin) {
+void GridMapGeo::setGlobalOrigin(EPSG src_coord, const Eigen::Vector3d origin) {
   // Transform global origin into CH1903 / LV03 coordinates
-  maporigin_.espg = src_coord;
+  maporigin_.epsg = src_coord;
   maporigin_.position = origin;
 }
 

--- a/grid_map_geo/src/terrain_loader.cpp
+++ b/grid_map_geo/src/terrain_loader.cpp
@@ -44,8 +44,8 @@
 
 #include <gdal/ogr_spatialref.h>
 
-constexpr int ESPG_WGS84 = 4326;
-constexpr int ESPG_CH1903_LV03 = 21781;
+constexpr int EPSG_WGS84 = 4326;
+constexpr int EPSG_CH1903_LV03 = 21781;
 
 void transformCoordinates(int src_coord, const double &x, const double &y, const double &z, int tgt_coord, double &x_t,
                           double &y_t, double &z_t) {
@@ -73,8 +73,8 @@ void LoadTerrainFromVrt(std::string path, const Eigen::Vector3d &query_position,
   Eigen::Vector3d query_position_lv03 = query_position;
   /// Convert LV03 to WGS84
   Eigen::Vector3d map_center_wgs84;  // Map center in WGS84
-  transformCoordinates(ESPG_CH1903_LV03, query_position_lv03(0), query_position_lv03(1), query_position_lv03(2),
-                       ESPG_WGS84, map_center_wgs84.x(), map_center_wgs84.y(), map_center_wgs84.z());
+  transformCoordinates(EPSG_CH1903_LV03, query_position_lv03(0), query_position_lv03(1), query_position_lv03(2),
+                       EPSG_WGS84, map_center_wgs84.x(), map_center_wgs84.y(), map_center_wgs84.z());
 
   std::cout << "Loading VRT Map:" << std::endl;
   std::cout << "  - map_center_wgs84:" << map_center_wgs84.transpose() << std::endl;
@@ -98,8 +98,8 @@ void LoadTerrainFromVrt(std::string path, const Eigen::Vector3d &query_position,
     auto cell_position_lv03 = cell_position + query_position_lv03.head(2);  // Position of cell in CH1903/LV03
     double dummy;
     Eigen::Vector2d cell_position_wgs84;
-    transformCoordinates(ESPG_CH1903_LV03, cell_position_lv03(0), cell_position_lv03(1), cell_position_lv03(2),
-                         ESPG_WGS84, cell_position_wgs84.x(), cell_position_wgs84.y(), dummy);
+    transformCoordinates(EPSG_CH1903_LV03, cell_position_lv03(0), cell_position_lv03(1), cell_position_lv03(2),
+                         EPSG_WGS84, cell_position_wgs84.x(), cell_position_wgs84.y(), dummy);
     // std::cout << "    - cell_position_wgs84:" << cell_position_wgs84.transpose() << std::endl;
 
     Eigen::Vector2d local_wgs84 = cell_position_wgs84 - map_center_wgs84.head(2);

--- a/grid_map_geo/test/test_grid_map_geo.cpp
+++ b/grid_map_geo/test/test_grid_map_geo.cpp
@@ -11,11 +11,11 @@ TEST(GridMapTest, geoTransform) {
   Eigen::Vector3d berghaus_wgs84(9.9219592, 46.7209147, 488.0);
 #endif
   Eigen::Vector3d berghaus_lv03(789823.96735451114, 177416.47911055354, 440.3752994351089);
-  Eigen::Vector3d tranformed_lv03 = transformCoordinates(ESPG::WGS84, ESPG::CH1903_LV03, berghaus_wgs84);
+  Eigen::Vector3d tranformed_lv03 = transformCoordinates(EPSG::WGS84, EPSG::CH1903_LV03, berghaus_wgs84);
   EXPECT_NEAR(tranformed_lv03(0), berghaus_lv03(0), 0.0001);
   EXPECT_NEAR(tranformed_lv03(1), berghaus_lv03(1), 0.0001);
   // EXPECT_NEAR(tranformed_lv03(2), berghaus_lv03(2), 0.0001);
-  Eigen::Vector3d tranformed_wgs84 = transformCoordinates(ESPG::CH1903_LV03, ESPG::WGS84, berghaus_lv03);
+  Eigen::Vector3d tranformed_wgs84 = transformCoordinates(EPSG::CH1903_LV03, EPSG::WGS84, berghaus_lv03);
   EXPECT_NEAR(tranformed_wgs84(0), berghaus_wgs84(0), 0.0001);
   EXPECT_NEAR(tranformed_wgs84(1), berghaus_wgs84(1), 0.0001);
   // EXPECT_NEAR(tranformed_wgs84(2), berghaus_wgs84(2), 0.0001);
@@ -29,7 +29,7 @@ TEST(GridMapTest, geoTransform) {
       "PARAMETER[\"rectified_grid_angle\", 90], PARAMETER[\"scale_factor\", 1], PARAMETER[\"false_easting\", 600000], "
       "PARAMETER[\"false_northing\", 200000], UNIT[\"metre\", 1, AUTHORITY[\"EPSG\", \"9001\"]], AXIS[\"Y\", EAST], "
       "AXIS[\"X\", NORTH], AUTHORITY[\"EPSG\", \"21781\"]]";
-  Eigen::Vector3d tranformed_lv032 = transformCoordinates(ESPG::WGS84, wkt, berghaus_wgs84);
+  Eigen::Vector3d tranformed_lv032 = transformCoordinates(EPSG::WGS84, wkt, berghaus_wgs84);
   EXPECT_NEAR(tranformed_lv032(0), berghaus_lv03(0), 0.0001);
   EXPECT_NEAR(tranformed_lv032(1), berghaus_lv03(1), 0.0001);
   // EXPECT_NEAR(tranformed_lv032(2), berghaus_lv03(2), 0.0001);

--- a/grid_map_geo_msgs/msg/GeographicMapInfo.msg
+++ b/grid_map_geo_msgs/msg/GeographicMapInfo.msg
@@ -4,7 +4,7 @@
 std_msgs/Header header
 
 
-# ESPG of the coordinate the map is in
+# EPSG of the coordinate the map is in
 uint16 geo_coordinate
 
 # Size of the map in pixels


### PR DESCRIPTION
- renamed ESPG to EPSG, as its the European Petroleum Survey Group
- set the epsg field based on the provided geotiff epsg, and not hardcoded. enables use of non CH1903 geotiffs